### PR TITLE
Revise Notion Integration Guide for API usage

### DIFF
--- a/documentation/NOTION_INTEGRATION.md
+++ b/documentation/NOTION_INTEGRATION.md
@@ -1,164 +1,63 @@
-# Notion MCP Integration Guide
+# Notion Integration Guide
 
 ## Overview
-
-This guide shows you how to integrate Notion's official MCP server with Context Sync, enabling AI assistants to read and write Notion pages, search your knowledge base, and manage documentation.
-
+This guide shows you how to connect Context Sync directly to Notion using the official Notion API. You’ll be able to read and write Notion pages, search your workspace, and manage documentation—no separate MCP server required!
 ## Prerequisites
 
 - Node.js 16+ installed
 - A Notion account with workspace access
 - Notion API integration token
+## Step 1: Get Your Notion API Token
+   go to -> https://www.notion.so/profile/integrations
+1. **Create a Notion Integration:**
+  - Give it a name (e.g., "Context Sync")
+  - Select your workspace
+  - Click "Submit"
+2. **Share Pages access with Your Integration:**
+  - Click access under the newly created intergration.
 
-## Step 1: Get Notion API Token
-
-1. **Create Notion Integration:**
-   - Go to https://www.notion.so/my-integrations
-   - Click "New integration"
-   - Give it a name (e.g., "Context Sync MCP")
-   - Select your workspace
-   - Click "Submit"
-
-2. **Copy Your API Token:**
-   - After creation, you'll see an "Internal Integration Token"
-   - Copy this token (starts with `secret_`)
-   - **Keep this secure!** Never commit it to version control
-
-3. **Share Pages with Integration:**
-   - Open the Notion pages you want the AI to access
-   - Click "..." (three dots) → "Add connections"
-   - Select your integration name
-   - The integration now has access to those pages
-
-## Step 2: Install Notion MCP Server
-
-The official Notion MCP server is maintained by Notion:
+3. **Copy your Integration Secret**
+   - The secrete starts with ntn_ or secret_
+  
+## Step 2: Install Context Sync
 
 ```bash
-# Install globally (optional)
-npm install -g @notionhq/mcp-server-notion
-
-# Or use with npx (recommended)
-npx @notionhq/mcp-server-notion
+npm install -g @context-sync/server
 ```
+## Step 3: Run the Setup Wizard
 
-## Step 3: Configure Claude Desktop
-
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "notion": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@notionhq/mcp-server-notion"
-      ],
-      "env": {
-        "NOTION_API_KEY": "secret_YOUR_TOKEN_HERE"
-      }
-    }
-  }
-}
+Just run:
+```bash
+context-sync-setup
 ```
+The wizard will prompt you for your Notion API token and handle the rest!
+## Step 4: Start Using Notion with Context Sync
 
-**Windows Path:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-## Step 4: Configure Other AI Platforms
-
-### Cursor IDE
-
-Add to `.cursorrules` or Cursor settings:
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "notion": {
-        "command": "npx",
-        "args": ["-y", "@notionhq/mcp-server-notion"],
-        "env": {
-          "NOTION_API_KEY": "secret_YOUR_TOKEN_HERE"
-        }
-      }
-    }
-  }
-}
-```
-
-### Continue.dev
-
-Add to `~/.continue/config.json`:
-
-```json
-{
-  "mcpServers": [
-    {
-      "name": "notion",
-      "command": "npx",
-      "args": ["-y", "@notionhq/mcp-server-notion"],
-      "env": {
-        "NOTION_API_KEY": "secret_YOUR_TOKEN_HERE"
-      }
-    }
-  ]
-}
-```
-
+You’re all set! Context Sync will connect directly to Notion using your API token. No extra server or config needed.
 ## Step 5: Test the Integration
 
-Restart your AI assistant and try:
-
-```
-"Search my Notion workspace for documentation about API authentication"
-```
-
-```
-"Create a new Notion page titled 'Project Plan' with sections for Timeline and Budget"
-```
-
-```
-"Read the Notion page about deployment procedures and summarize it"
-```
-
+Try searching, reading, or creating pages in Notion using Context Sync’s tools and commands. If you run into any issues, check your API token and make sure the pages are shared with your integration.
 ## Available Capabilities
 
-Once configured, your AI can:
-
-### Search & Read
+Once configured, you can:
 - 🔍 Search all accessible Notion pages
 - 📖 Read full page content (including blocks and databases)
-- 🔗 Follow page relationships and links
-
-### Create & Update
 - ✍️ Create new pages with rich content
 - 📝 Update existing page content
 - 🏗️ Add blocks (text, headings, lists, code, etc.)
 - 📊 Create and update database entries
-
-### Organization
 - 📁 Organize pages in hierarchies
 - 🏷️ Add tags and properties
 - 🔗 Create relationships between pages
-
 ## Security Best Practices
 
 1. **Token Management:**
-   ```bash
-   # Use environment variables
-   export NOTION_API_KEY="secret_YOUR_TOKEN_HERE"
-   ```
-
+  - Keep your API token secure. Never commit it to version control.
 2. **Minimal Access:**
-   - Only share specific pages with the integration
-   - Don't give access to sensitive workspaces
-
+  - Only share specific pages with the integration.
 3. **Regular Review:**
-   - Periodically check https://www.notion.so/my-integrations
-   - Revoke access to unused pages
-   - Rotate tokens if compromised
-
+  - Periodically check https://www.notion.so/my-integrations
+  - Revoke access to unused pages
 ## Troubleshooting
 
 ### "Integration not found" Error
@@ -173,69 +72,21 @@ Once configured, your AI can:
 ```bash
 # Check Node version
 node --version  # Should be 16+
-
-# Test server manually
-npx @notionhq/mcp-server-notion
-
-# Check for errors in Claude logs
-tail -f ~/Library/Logs/Claude/mcp*.log
 ```
-
 ## Example Use Cases
 
 ### 1. Documentation Management
-```
-"Create a troubleshooting guide in Notion for the authentication errors we discussed"
-```
-
-### 2. Meeting Notes
-```
-"Search my Notion for notes from the Q1 planning meeting"
-```
-
-### 3. Knowledge Base
-```
-"Update the API documentation page in Notion with the new endpoints we just created"
-```
-
-### 4. Project Planning
-```
-"Create a project roadmap page with milestones for Q2"
-```
-
+- "Create a troubleshooting guide in Notion for the authentication errors we discussed"
+- "Search my Notion for notes from the Q1 planning meeting"
+- "Update the API documentation page in Notion with the new endpoints we just created"
+- "Create a project roadmap page with milestones for Q2"
 ## Context Sync Integration
 
-Context Sync now recognizes Notion as a platform:
-
-```typescript
-// Check if Notion is configured
-const status = await mcp.call_tool("context-sync", 
-  "get_platform_status", {});
-
-// Switch to Notion for documentation work
-const handoff = await mcp.call_tool("context-sync",
-  "switch_platform", {
-    fromPlatform: "cursor",
-    toPlatform: "notion"
-  });
-```
-
-## Further Resources
-
-- **Official Docs:** https://github.com/makenotion/notion-mcp-server
+Context Sync recognizes Notion as a platform and can sync, search, and update docs directly.
 - **Notion API:** https://developers.notion.com
-- **MCP Spec:** https://modelcontextprotocol.io
 - **Context Sync:** https://github.com/Intina47/context-sync
-
 ## Next Steps
 
 1. ✅ Set up Notion integration token
-2. ✅ Configure MCP server in your AI assistant
-3. ✅ Share relevant pages with the integration
-4. 🚀 Start using Notion with AI!
-
----
-
-**Questions or Issues?**
-- File an issue: https://github.com/Intina47/context-sync/issues
-- Notion MCP issues: https://github.com/makenotion/notion-mcp-server/issues
+2. ✅ Share relevant pages with the integration
+3. 🚀 Start using Notion with Context Sync!


### PR DESCRIPTION
#17 #18 

Updated the Notion integration guide to reflect direct API usage and removed references to MCP server.

Thanks to [bemcgrath](https://github.com/bemcgrath) for flagging this issue.