### PR TITLE
fix: remove BOM from setup script

### DIFF
--- a/bin/setup.cjs
+++ b/bin/setup.cjs
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env node
+#!/usr/bin/env node
 
 /**
  * Context Sync Setup CLI

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -23,3 +23,4 @@ This release is a major v2-focused cleanup. It removes legacy v1 tooling and nar
 ## Notes
 - Auto-config does not run on local installs; use global install or manual config.
 - Notion setup is intentionally manual via the wizard.
+- Fixed Windows setup command failing due to a stray BOM in the setup script.


### PR DESCRIPTION
### Motivation
- Windows users experienced a `SyntaxError: Invalid or unexpected token` when running the global setup command because a stray BOM preceded the shebang in the CLI entrypoint.

### Description
- Strip the BOM from the CLI entrypoint file `bin/setup.cjs` so the file now begins with the shebang line only.
- Document the fix in `docs/RELEASE_NOTES.md` noting that the Windows setup command failure was resolved.

### Testing
- No automated tests were run for this change; this repository does not include automated tests for the installer and `npm test` is a placeholder.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697baac17bd4832d89f7c3dc5664a65a)