### PR TITLE
feat: show auto-config status in setup wizard

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This release is a major v2-focused cleanup. It removes legacy v1 tooling and nar
 - Unified auto-config format with per-platform adapters.
 - Notion-only setup wizard with clearer prompts and retry flow.
 - Post-install status tracking with manual-config fallback when auto-config fails.
+- Setup wizard now summarizes auto-configured platforms and any install issues.
 
 ## Breaking changes
 - Removed v1-only tools (todos, platform sync, call graph, type analysis, dependency analysis, file write/preview tools, performance monitor, migration prompter, and related modules).


### PR DESCRIPTION
### Motivation
- Users need visibility into which platforms were auto-configured during package install and any issues so the interactive setup (`context-sync-setup`) can surface that information.

### Description
- Added install-status loading and a summary renderer to `bin/setup.cjs` by introducing `PLATFORM_CONFIGS`, `STATUS_FILE`, `loadInstallStatus`, `getPlatformLabel`, `renderList`, and `showAutoConfigSummary` helpers and calling `showAutoConfigSummary` from `main`.
- The summary shows configured platforms, skipped platforms with reasons, errors, and whether manual configuration may be required, and points users at `docs/CONFIG.md` or `npm install -g @context-sync/server` when no status is available.
- Updated `docs/RELEASE_NOTES.md` to document the new setup summary behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bacf5354c832db849b80ddf7f363c)