### PR TITLE
feat: add curl-based installer and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ Local-first memory layer for AI development tools via MCP.
 ![alt text](image.png)
 
 ## Install and auto-config (60 seconds)
-1) Install globally:
+Choose one install method:
+
+**Option A: npm (recommended)**
 ```bash
 npm install -g @context-sync/server
 ```
+
+**Option B: curl**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Intina47/context-sync/main/bin/install.sh | bash
+```
+
+Requires Node.js 18+ and npm.
 
 2) Auto-config runs on install. Restart your AI tool.
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_NAME="@context-sync/server"
+VERSION_SUFFIX=""
+
+if [[ -n "${CONTEXT_SYNC_VERSION:-}" ]]; then
+  VERSION_SUFFIX="@${CONTEXT_SYNC_VERSION}"
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Node.js is required (>= 18). Install Node.js and retry." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "❌ npm is required. Install npm and retry." >&2
+  exit 1
+fi
+
+echo "🧠 Installing Context Sync MCP Server..."
+
+npm install -g "${PACKAGE_NAME}${VERSION_SUFFIX}"
+
+echo "✅ Install complete. Restart your AI tool to load Context Sync."

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This release is a major v2-focused cleanup. It removes legacy v1 tooling and nar
 - Notion-only setup wizard with clearer prompts and retry flow.
 - Post-install status tracking with manual-config fallback when auto-config fails.
 - Setup wizard now summarizes auto-configured platforms and any install issues.
+- Added a curl-based installer for global installs.
 
 ## Breaking changes
 - Removed v1-only tools (todos, platform sync, call graph, type analysis, dependency analysis, file write/preview tools, performance monitor, migration prompter, and related modules).
@@ -25,3 +26,4 @@ This release is a major v2-focused cleanup. It removes legacy v1 tooling and nar
 - Auto-config does not run on local installs; use global install or manual config.
 - Notion setup is intentionally manual via the wizard.
 - Fixed Windows setup command failing due to a stray BOM in the setup script.
+- The curl installer wraps the same npm global install flow.


### PR DESCRIPTION
### Motivation
- Provide an alternative distribution method so users can install Context Sync via a one-line `curl | bash` flow for environments where invoking `npm` directly is less convenient. 
- Preserve the existing global install behavior and auto-config pathway while making installation easier to discover and run.

### Description
- Add a portable bash installer at `bin/install.sh` that checks for `node` and `npm`, supports pinning a release via `CONTEXT_SYNC_VERSION`, and runs `npm install -g "@context-sync/server${VERSION_SUFFIX}"`.
- Document the new curl install option and system requirements in `README.md` with the example `curl -fsSL https://raw.githubusercontent.com/Intina47/context-sync/main/bin/install.sh | bash` command and Node/npm requirement.
- Note the new curl-based installer in `docs/RELEASE_NOTES.md` and clarify that the curl installer wraps the same npm global install flow.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e077d2374832da7ea9904ef1b8235)